### PR TITLE
Add simple health check

### DIFF
--- a/uwsgi_exporter.go
+++ b/uwsgi_exporter.go
@@ -47,6 +47,10 @@ func main() {
 			</body>
 			</html>`))
 	})
+	http.HandleFunc("/-/healthy", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte("ok"))
+	})
 
 	log.Infoln("Listening on", *listenAddress)
 	err := http.ListenAndServe(*listenAddress, nil)


### PR DESCRIPTION
Useful to check health status of a running container using a `livenessProbe` in a Kubernetes Pod.