### PR TITLE
Fix bug in multi-target mode, metrics like uwsgi_up may be wrong

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ scrape_configs:
         # All uwsgi hostnames to monitor.
         - http://uwsgi1.example.com:5432
         - http://uwsgi2.example.com:5432
+    metrics_path: "/probe"
     relabel_configs:
       - source_labels: [__address__]
         target_label: __param_target


### PR DESCRIPTION
In multi-targets mode, all targets shares only one metrics object concurrently, this may result in weird bug like returning some targets's `uwsgi_up` result to other targets request.

The approach I use for fixing this bug is to store metrics objects into an sync.Map, using the target as key. Thus each target request has it's own scope.